### PR TITLE
Add focus-aware autosave control

### DIFF
--- a/src/components/codemirror-editor.tsx
+++ b/src/components/codemirror-editor.tsx
@@ -14,6 +14,8 @@ interface CodeMirrorEditorProps {
   onChange$: PropFunction<(next: string) => void>;
   onViewReady$?: PropFunction<(view: unknown) => void>;
   onDispose$?: PropFunction<() => void>;
+  onFocus$?: PropFunction<() => void>;
+  onBlur$?: PropFunction<() => void>;
   variant?: "default" | "live";
 }
 
@@ -24,6 +26,8 @@ export const CodeMirrorEditor = component$(
     onChange$,
     onViewReady$,
     onDispose$,
+    onFocus$,
+    onBlur$,
     variant = "default",
   }: CodeMirrorEditorProps) => {
     const containerRef = useSignal<HTMLDivElement>();
@@ -288,6 +292,24 @@ export const CodeMirrorEditor = component$(
         editorViewSignal.value = view;
         editorReady.value = true;
 
+        const focusListener = onFocus$
+          ? () => {
+              void onFocus$();
+            }
+          : undefined;
+        const blurListener = onBlur$
+          ? () => {
+              void onBlur$();
+            }
+          : undefined;
+
+        if (focusListener) {
+          view.dom.addEventListener("focus", focusListener, true);
+        }
+        if (blurListener) {
+          view.dom.addEventListener("blur", blurListener, true);
+        }
+
         // Formatting visibility is handled by the decoration plugin (no DOM selection listeners needed)
 
         requestAnimationFrame(() => {
@@ -352,6 +374,12 @@ export const CodeMirrorEditor = component$(
             void 0;
           }
           editorReady.value = false;
+          if (focusListener) {
+            view.dom.removeEventListener("focus", focusListener, true);
+          }
+          if (blurListener) {
+            view.dom.removeEventListener("blur", blurListener, true);
+          }
           editorViewSignal.value = undefined;
           editorStateSignal.value = undefined;
           themeCompartmentSignal.value = undefined;

--- a/src/lib/state/diaryx-context.ts
+++ b/src/lib/state/diaryx-context.ts
@@ -17,6 +17,7 @@ export interface DiaryxUiState {
   editorMode: "split" | "source" | "preview" | "live";
   showSettings: boolean;
   libraryMode: LibraryMode;
+  editorHasFocus: boolean;
 }
 
 export interface DiaryxSessionState {

--- a/src/lib/state/use-diaryx-session.ts
+++ b/src/lib/state/use-diaryx-session.ts
@@ -23,6 +23,7 @@ const createInitialState = (): DiaryxSessionState => {
       editorMode: "split",
       showSettings: false,
       libraryMode: "all",
+      editorHasFocus: false,
     },
     importState: {
       isImporting: false,


### PR DESCRIPTION
## Summary
- add an editorHasFocus flag to the UI store and propagate focus/blur events from both editor implementations
- track dirty state in NoteEditor so notes are stamped on blur and toggle the shared focus flag accordingly
- refactor the autosave routine to defer persistence while focused, flush pending writes on blur or app mutations, and add a beforeunload safety flush

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d70ea74e38832c909d7b39fe9f4575